### PR TITLE
Create sanity espresso tests

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -50,8 +50,12 @@ def androidx = [
 
 def test = [
         junit      : 'junit:junit:4.12',
-        truth      : 'com.google.truth:truth:0.43',
-        robolectric: 'org.robolectric:robolectric:4.2'
+        truth      : 'com.google.truth:truth:0.46',
+        robolectric: 'org.robolectric:robolectric:4.2',
+        espresso   : 'androidx.test.espresso:espresso-core:3.2.0',
+        runner     : 'androidx.test:runner:1.2.0',
+        rules      : 'androidx.test:rules:1.2.0',
+        orchestrator : 'androidx.test:orchestrator:1.2.0',
 ]
 
 def kotlin = [

--- a/protosimplestore/build.gradle
+++ b/protosimplestore/build.gradle
@@ -11,6 +11,16 @@ android {
     defaultConfig {
         minSdkVersion deps.build.minSdkVersion
         targetSdkVersion deps.build.targetSdkVersion
+
+        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+        // The following argument makes the Android Test Orchestrator run its
+        // "pm clear" command after each test invocation. This command ensures
+        // that the app's state is completely cleared between tests.
+        testInstrumentationRunnerArguments clearPackageData: 'true'
+    }
+
+    testOptions {
+        execution 'ANDROIDX_TEST_ORCHESTRATOR'
     }
 
     defaultConfig {
@@ -47,6 +57,11 @@ dependencies {
     testImplementation deps.test.junit
     testImplementation deps.test.truth
     testImplementation deps.test.robolectric
+
+    androidTestImplementation deps.test.runner
+    androidTestImplementation deps.test.rules
+
+    androidTestUtil deps.test.orchestrator
 }
 
 apply plugin: 'com.vanniktech.maven.publish'

--- a/protosimplestore/src/androidTest/java/com/uber/simplestore/proto/SanityEspressoTest.java
+++ b/protosimplestore/src/androidTest/java/com/uber/simplestore/proto/SanityEspressoTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (C) 2019. Uber Technologies
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.uber.simplestore.proto;
+
+import static org.junit.Assert.assertEquals;
+
+import android.content.Context;
+import androidx.test.filters.LargeTest;
+import androidx.test.platform.app.InstrumentationRegistry;
+import androidx.test.runner.AndroidJUnit4;
+import com.uber.simplestore.ScopeConfig;
+import com.uber.simplestore.proto.impl.SimpleProtoStoreFactory;
+import com.uber.simplestore.proto.test.TestProto;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(AndroidJUnit4.class)
+@LargeTest
+public class SanityEspressoTest {
+
+  private static final String TEST_SCOPE = "test_scope";
+  private static final String KEY_ONE = "key_one";
+  private static final String SAMPLE_STRING = "persisted_value";
+  private Context context = InstrumentationRegistry.getInstrumentation().getTargetContext();
+
+  @Test
+  public void defaultScope() throws Exception {
+    SimpleProtoStore store = SimpleProtoStoreFactory.create(context, TEST_SCOPE);
+    TestProto.Basic proto = TestProto.Basic.newBuilder().setName(SAMPLE_STRING).build();
+    store.put(KEY_ONE, proto).get();
+    store.close();
+
+    SimpleProtoStore storeTwo = SimpleProtoStoreFactory.create(context, TEST_SCOPE);
+    TestProto.Basic fromDisk = storeTwo.get(KEY_ONE, TestProto.Basic.parser()).get();
+    assertEquals(proto.getName(), fromDisk.getName());
+    storeTwo.close();
+  }
+
+  @Test
+  public void cache() throws Exception {
+    SimpleProtoStore store = SimpleProtoStoreFactory.create(context, TEST_SCOPE, ScopeConfig.CACHE);
+    TestProto.Basic proto = TestProto.Basic.newBuilder().setName(SAMPLE_STRING).build();
+    store.put(KEY_ONE, proto).get();
+    store.close();
+
+    SimpleProtoStore storeTwo =
+        SimpleProtoStoreFactory.create(context, TEST_SCOPE, ScopeConfig.CACHE);
+    TestProto.Basic fromDisk = storeTwo.get(KEY_ONE, TestProto.Basic.parser()).get();
+    assertEquals(proto.getName(), fromDisk.getName());
+    storeTwo.close();
+  }
+}

--- a/protosimplestore/src/androidTest/proto/TestProto.proto
+++ b/protosimplestore/src/androidTest/proto/TestProto.proto
@@ -1,0 +1,16 @@
+syntax = "proto2";
+
+package uber.simplestore;
+
+option java_package = "com.uber.simplestore.proto.test";
+option java_outer_classname = "TestProto";
+
+message Basic {
+    optional string name = 1;
+}
+
+message Required {
+    optional string option = 1;
+    required string withDefault = 2 [default = "default"];
+    required string noDefault = 3;
+}

--- a/simplestore/build.gradle
+++ b/simplestore/build.gradle
@@ -10,6 +10,16 @@ android {
     defaultConfig {
         minSdkVersion deps.build.minSdkVersion
         targetSdkVersion deps.build.targetSdkVersion
+
+        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+        // The following argument makes the Android Test Orchestrator run its
+        // "pm clear" command after each test invocation. This command ensures
+        // that the app's state is completely cleared between tests.
+        testInstrumentationRunnerArguments clearPackageData: 'true'
+    }
+
+    testOptions {
+        execution 'ANDROIDX_TEST_ORCHESTRATOR'
     }
 
     defaultConfig {
@@ -30,6 +40,11 @@ dependencies {
     testImplementation deps.test.junit
     testImplementation deps.test.truth
     testImplementation deps.test.robolectric
+
+    androidTestImplementation deps.test.runner
+    androidTestImplementation deps.test.rules
+
+    androidTestUtil deps.test.orchestrator
 }
 
 apply plugin: 'com.vanniktech.maven.publish'

--- a/simplestore/src/androidTest/java/com/uber/simplestore/SanityEspressoTest.java
+++ b/simplestore/src/androidTest/java/com/uber/simplestore/SanityEspressoTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (C) 2019. Uber Technologies
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.uber.simplestore;
+
+import static org.junit.Assert.assertEquals;
+
+import android.content.Context;
+import androidx.test.filters.LargeTest;
+import androidx.test.platform.app.InstrumentationRegistry;
+import androidx.test.runner.AndroidJUnit4;
+import com.uber.simplestore.impl.SimpleStoreFactory;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(AndroidJUnit4.class)
+@LargeTest
+public class SanityEspressoTest {
+
+  private static final String TEST_SCOPE = "test_scope";
+  private static final String KEY_ONE = "key_one";
+  private static final String SAMPLE_STRING = "persisted_value";
+  private static final byte[] SOME_BYTES = new byte[] {0xD, 0xE, 0xA, 0xD, 0x0, 0xB, 0xE, 0xE, 0xF};
+  private Context context = InstrumentationRegistry.getInstrumentation().getTargetContext();
+
+  @Test
+  public void defaultScope_bytes() throws Exception {
+    SimpleStore store = SimpleStoreFactory.create(context, TEST_SCOPE);
+    store.put(KEY_ONE, SOME_BYTES).get();
+    store.close();
+
+    SimpleStore storeTwo = SimpleStoreFactory.create(context, TEST_SCOPE);
+    byte[] fromDisk = storeTwo.get(KEY_ONE).get();
+    assertEquals(SOME_BYTES, fromDisk);
+    storeTwo.close();
+  }
+
+  @Test
+  public void defaultScope_string() throws Exception {
+    SimpleStore store = SimpleStoreFactory.create(context, TEST_SCOPE);
+    store.putString(KEY_ONE, SAMPLE_STRING).get();
+    store.close();
+
+    SimpleStore storeTwo = SimpleStoreFactory.create(context, TEST_SCOPE);
+    String fromDisk = storeTwo.getString(KEY_ONE).get();
+    assertEquals(SAMPLE_STRING, fromDisk);
+    storeTwo.close();
+  }
+
+  @Test
+  public void cache() throws Exception {
+    SimpleStore store = SimpleStoreFactory.create(context, TEST_SCOPE, ScopeConfig.CACHE);
+    store.putString(KEY_ONE, SAMPLE_STRING).get();
+    store.close();
+
+    SimpleStore storeTwo = SimpleStoreFactory.create(context, TEST_SCOPE, ScopeConfig.CACHE);
+    String fromDisk = storeTwo.getString(KEY_ONE).get();
+    assertEquals(SAMPLE_STRING, fromDisk);
+    storeTwo.close();
+  }
+}


### PR DESCRIPTION
These can be used to ensure everything is fine on a specific OS version
(such as minSDK)

Theoretically we could run these on CI against a Firebase Test Lab matrix.