### PR TITLE
deleteAll is now recursive

### DIFF
--- a/simplestore/src/main/java/com/uber/simplestore/SimpleStore.java
+++ b/simplestore/src/main/java/com/uber/simplestore/SimpleStore.java
@@ -75,7 +75,7 @@ public interface SimpleStore extends Closeable {
   @CheckReturnValue
   ListenableFuture<Boolean> contains(String key);
 
-  /** Delete all keys in this direct scope. */
+  /** Recursively delete all keys in this scope and child scopes. */
   @CheckReturnValue
   ListenableFuture<Void> deleteAll();
 

--- a/simplestore/src/test/java/com/uber/simplestore/impl/SimpleStoreImplTest.java
+++ b/simplestore/src/test/java/com/uber/simplestore/impl/SimpleStoreImplTest.java
@@ -87,10 +87,24 @@ public final class SimpleStoreImplTest {
   }
 
   @Test
-  public void deleteAll() throws Exception {
+  public void deleteAll_noChildren() throws Exception {
     try (SimpleStore store = SimpleStoreFactory.create(context, "")) {
       store.put(TEST_KEY, new byte[1]).get();
       store.deleteAll().get();
+      ListenableFuture<byte[]> empty = store.get(TEST_KEY);
+      assertThat(empty.get()).isEmpty();
+    }
+  }
+
+  @Test
+  public void deleteAll_withChildren() throws Exception {
+    try (SimpleStore store = SimpleStoreFactory.create(context, "parent/child")) {
+      store.put(TEST_KEY, new byte[1]).get();
+    }
+    try (SimpleStore store = SimpleStoreFactory.create(context, "parent")) {
+      store.deleteAll().get();
+    }
+    try (SimpleStore store = SimpleStoreFactory.create(context, "parent/child")) {
       ListenableFuture<byte[]> empty = store.get(TEST_KEY);
       assertThat(empty.get()).isEmpty();
     }

--- a/testing/src/test/java/com/uber/simplestore/fakes/FakeUnitTest.java
+++ b/testing/src/test/java/com/uber/simplestore/fakes/FakeUnitTest.java
@@ -44,6 +44,16 @@ public class FakeUnitTest {
   }
 
   @Test
+  public void deleteAll_noChildren() throws Exception {
+    try (SimpleStore store = new FakeSimpleStore()) {
+      store.put(TEST_KEY, new byte[1]).get();
+      store.deleteAll().get();
+      ListenableFuture<byte[]> empty = store.get(TEST_KEY);
+      assertThat(empty.get()).isEmpty();
+    }
+  }
+
+  @Test
   public void handlesAbsence() throws Exception {
     SimpleStore store = new FakeSimpleStore();
     assertThat(store.getString(TEST_KEY).get()).isEqualTo("");


### PR DESCRIPTION
As we started using this method, we realized that we always want all
child scopes to also be cleared. Child scopes are primarily used for
logged in users or for grouping a full feature together.

Added a test case to ensure the existing behavior remains in addition to
the recursion.