### PR TITLE
Support clearing a scope and all children of data

### DIFF
--- a/protosimplestore/src/main/java/com/uber/simplestore/proto/impl/SimpleProtoStoreImpl.java
+++ b/protosimplestore/src/main/java/com/uber/simplestore/proto/impl/SimpleProtoStoreImpl.java
@@ -122,8 +122,13 @@ public final class SimpleProtoStoreImpl implements SimpleProtoStore {
   }
 
   @Override
-  public ListenableFuture<Void> deleteAll() {
-    return simpleStore.deleteAll();
+  public ListenableFuture<Void> clear() {
+    return simpleStore.clear();
+  }
+
+  @Override
+  public ListenableFuture<Void> deleteAllNow() {
+    return simpleStore.deleteAllNow();
   }
 
   @Override

--- a/sample/src/main/java/com/uber/simplestore/sample/JavaActivity.java
+++ b/sample/src/main/java/com/uber/simplestore/sample/JavaActivity.java
@@ -65,7 +65,7 @@ public class JavaActivity extends AppCompatActivity {
         .setOnClickListener(
             (v) ->
                 Futures.addCallback(
-                    simpleStore.deleteAll(),
+                    simpleStore.clear(),
                     new FutureCallback<Void>() {
                       @Override
                       public void onSuccess(@NonNull Void result) {

--- a/sample/src/main/java/com/uber/simplestore/sample/KotlinActivity.kt
+++ b/sample/src/main/java/com/uber/simplestore/sample/KotlinActivity.kt
@@ -44,7 +44,7 @@ class KotlinActivity : AppCompatActivity() {
         }
         findViewById<View>(R.id.activity_main_clear)
             .setOnClickListener {
-                Futures.addCallback(simpleStore.deleteAll(), object : FutureCallback<Void> {
+                Futures.addCallback(simpleStore.clear(), object : FutureCallback<Void> {
                     override fun onSuccess(msg: Void?) {
                         loadMessage()
                     }

--- a/simplestore/src/main/java/com/uber/simplestore/SimpleStore.java
+++ b/simplestore/src/main/java/com/uber/simplestore/SimpleStore.java
@@ -15,6 +15,7 @@
  */
 package com.uber.simplestore;
 
+import com.google.common.annotations.Beta;
 import com.google.common.util.concurrent.ListenableFuture;
 import java.io.Closeable;
 import javax.annotation.CheckReturnValue;
@@ -77,7 +78,14 @@ public interface SimpleStore extends Closeable {
 
   /** Delete all keys in this direct namespace. */
   @CheckReturnValue
-  ListenableFuture<Void> deleteAll();
+  ListenableFuture<Void> clear();
+
+  /**
+   * Recursively delete all keys in this scope and child scopes. Fails all outstanding operations on
+   * the stores.
+   */
+  @Beta
+  ListenableFuture<Void> deleteAllNow();
 
   /** Fails all outstanding operations then releases the memory cache. */
   @Override

--- a/simplestore/src/main/java/com/uber/simplestore/StoreClosedException.java
+++ b/simplestore/src/main/java/com/uber/simplestore/StoreClosedException.java
@@ -16,4 +16,12 @@
 package com.uber.simplestore;
 
 /** Thrown when attempting to use a closed store. */
-public final class StoreClosedException extends RuntimeException {}
+public final class StoreClosedException extends RuntimeException {
+  public StoreClosedException() {
+    super();
+  }
+
+  public StoreClosedException(String message) {
+    super(message);
+  }
+}

--- a/simplestore/src/main/java/com/uber/simplestore/primitive/PrimitiveSimpleStoreImpl.java
+++ b/simplestore/src/main/java/com/uber/simplestore/primitive/PrimitiveSimpleStoreImpl.java
@@ -63,8 +63,13 @@ final class PrimitiveSimpleStoreImpl implements PrimitiveSimpleStore {
   }
 
   @Override
-  public ListenableFuture<Void> deleteAll() {
-    return simpleStore.deleteAll();
+  public ListenableFuture<Void> clear() {
+    return simpleStore.clear();
+  }
+
+  @Override
+  public ListenableFuture<Void> deleteAllNow() {
+    return simpleStore.deleteAllNow();
   }
 
   @Override

--- a/simplestore/src/test/java/com/uber/simplestore/impl/SimpleStoreFactoryTest.java
+++ b/simplestore/src/test/java/com/uber/simplestore/impl/SimpleStoreFactoryTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2019. Uber Technologies
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.uber.simplestore.impl;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import android.content.Context;
+import com.uber.simplestore.SimpleStore;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.RuntimeEnvironment;
+
+@RunWith(RobolectricTestRunner.class)
+public final class SimpleStoreFactoryTest {
+
+  private Context context = RuntimeEnvironment.systemContext;
+
+  @Test
+  public void findChildren() {
+    SimpleStore root = SimpleStoreFactory.create(context, "");
+    SimpleStore parent = SimpleStoreFactory.create(context, "parent");
+    SimpleStore child = SimpleStoreFactory.create(context, "parent/child");
+    SimpleStore leaf = SimpleStoreFactory.create(context, "leaf");
+
+    assertThat(SimpleStoreFactory.getOpenChildren("leaf")).isEmpty();
+    assertThat(SimpleStoreFactory.getOpenChildren("parent/child")).isEmpty();
+    assertThat(SimpleStoreFactory.getOpenChildren("parent")).containsExactly(child);
+    assertThat(SimpleStoreFactory.getOpenChildren("")).containsExactly(parent, child, leaf);
+
+    root.close();
+    parent.close();
+    child.close();
+    leaf.close();
+  }
+}

--- a/testing/src/main/java/com/uber/simplestore/fakes/FakeSimpleStore.java
+++ b/testing/src/main/java/com/uber/simplestore/fakes/FakeSimpleStore.java
@@ -77,7 +77,13 @@ public final class FakeSimpleStore implements SimpleStore {
   }
 
   @Override
-  public ListenableFuture<Void> deleteAll() {
+  public ListenableFuture<Void> clear() {
+    data.clear();
+    return returnOrFail(null);
+  }
+
+  @Override
+  public ListenableFuture<Void> deleteAllNow() {
     data.clear();
     return returnOrFail(null);
   }

--- a/testing/src/test/java/com/uber/simplestore/fakes/FakeUnitTest.java
+++ b/testing/src/test/java/com/uber/simplestore/fakes/FakeUnitTest.java
@@ -44,6 +44,16 @@ public class FakeUnitTest {
   }
 
   @Test
+  public void clear_noChildren() throws Exception {
+    try (SimpleStore store = new FakeSimpleStore()) {
+      store.put(TEST_KEY, new byte[1]).get();
+      store.clear().get();
+      ListenableFuture<byte[]> empty = store.get(TEST_KEY);
+      assertThat(empty.get()).isEmpty();
+    }
+  }
+
+  @Test
   public void handlesAbsence() throws Exception {
     SimpleStore store = new FakeSimpleStore();
     assertThat(store.getString(TEST_KEY).get()).isEqualTo("");


### PR DESCRIPTION
A common use case for SimpleStore is to store account-specific data.
Generally you want to delete all account specific data from the device
upon logout. The new deleteAllNow() method will fail all outstanding IO
operations for a parent scope and all child scopes while removing
everything from disk.

The new clear() method has the old behavior of clearing all keys from a
single scope.

While heavily tested with Robolectric, deleteAllNow should be considered
beta.