### PR TITLE
Rename scope -> namespace

### DIFF
--- a/protosimplestore/src/androidTest/java/com/uber/simplestore/proto/SanityEspressoTest.java
+++ b/protosimplestore/src/androidTest/java/com/uber/simplestore/proto/SanityEspressoTest.java
@@ -21,7 +21,7 @@ import android.content.Context;
 import androidx.test.filters.LargeTest;
 import androidx.test.platform.app.InstrumentationRegistry;
 import androidx.test.runner.AndroidJUnit4;
-import com.uber.simplestore.ScopeConfig;
+import com.uber.simplestore.NamespaceConfig;
 import com.uber.simplestore.proto.impl.SimpleProtoStoreFactory;
 import com.uber.simplestore.proto.test.TestProto;
 import org.junit.Test;
@@ -31,19 +31,19 @@ import org.junit.runner.RunWith;
 @LargeTest
 public class SanityEspressoTest {
 
-  private static final String TEST_SCOPE = "test_scope";
+  private static final String TEST_NAMESPACE = "test_namespace";
   private static final String KEY_ONE = "key_one";
   private static final String SAMPLE_STRING = "persisted_value";
   private Context context = InstrumentationRegistry.getInstrumentation().getTargetContext();
 
   @Test
-  public void defaultScope() throws Exception {
-    SimpleProtoStore store = SimpleProtoStoreFactory.create(context, TEST_SCOPE);
+  public void defaultNamespace() throws Exception {
+    SimpleProtoStore store = SimpleProtoStoreFactory.create(context, TEST_NAMESPACE);
     TestProto.Basic proto = TestProto.Basic.newBuilder().setName(SAMPLE_STRING).build();
     store.put(KEY_ONE, proto).get();
     store.close();
 
-    SimpleProtoStore storeTwo = SimpleProtoStoreFactory.create(context, TEST_SCOPE);
+    SimpleProtoStore storeTwo = SimpleProtoStoreFactory.create(context, TEST_NAMESPACE);
     TestProto.Basic fromDisk = storeTwo.get(KEY_ONE, TestProto.Basic.parser()).get();
     assertEquals(proto.getName(), fromDisk.getName());
     storeTwo.close();
@@ -51,13 +51,14 @@ public class SanityEspressoTest {
 
   @Test
   public void cache() throws Exception {
-    SimpleProtoStore store = SimpleProtoStoreFactory.create(context, TEST_SCOPE, ScopeConfig.CACHE);
+    SimpleProtoStore store =
+        SimpleProtoStoreFactory.create(context, TEST_NAMESPACE, NamespaceConfig.CACHE);
     TestProto.Basic proto = TestProto.Basic.newBuilder().setName(SAMPLE_STRING).build();
     store.put(KEY_ONE, proto).get();
     store.close();
 
     SimpleProtoStore storeTwo =
-        SimpleProtoStoreFactory.create(context, TEST_SCOPE, ScopeConfig.CACHE);
+        SimpleProtoStoreFactory.create(context, TEST_NAMESPACE, NamespaceConfig.CACHE);
     TestProto.Basic fromDisk = storeTwo.get(KEY_ONE, TestProto.Basic.parser()).get();
     assertEquals(proto.getName(), fromDisk.getName());
     storeTwo.close();

--- a/protosimplestore/src/main/java/com/uber/simplestore/proto/impl/SimpleProtoStoreFactory.java
+++ b/protosimplestore/src/main/java/com/uber/simplestore/proto/impl/SimpleProtoStoreFactory.java
@@ -16,21 +16,23 @@
 package com.uber.simplestore.proto.impl;
 
 import android.content.Context;
-import com.uber.simplestore.ScopeConfig;
+import com.uber.simplestore.NamespaceConfig;
 import com.uber.simplestore.impl.SimpleStoreFactory;
 import com.uber.simplestore.proto.SimpleProtoStore;
 
 /**
- * Obtain an instance of a storage scope with proto support. Only one instance per scope may exist
- * at any time.
+ * Obtain an instance of a storage namespace with proto support. Only one instance per namespace may
+ * exist at any time.
+ *
+ * <p>Delegates to {@link SimpleStoreFactory#create(Context, String, NamespaceConfig)}.
  */
 public final class SimpleProtoStoreFactory {
 
-  public static SimpleProtoStore create(Context context, String scope) {
-    return create(context, scope, ScopeConfig.DEFAULT);
+  public static SimpleProtoStore create(Context context, String namespace) {
+    return create(context, namespace, NamespaceConfig.DEFAULT);
   }
 
-  public static SimpleProtoStore create(Context context, String scope, ScopeConfig config) {
-    return new SimpleProtoStoreImpl(SimpleStoreFactory.create(context, scope, config), config);
+  public static SimpleProtoStore create(Context context, String namespace, NamespaceConfig config) {
+    return new SimpleProtoStoreImpl(SimpleStoreFactory.create(context, namespace, config), config);
   }
 }

--- a/protosimplestore/src/main/java/com/uber/simplestore/proto/impl/SimpleProtoStoreImpl.java
+++ b/protosimplestore/src/main/java/com/uber/simplestore/proto/impl/SimpleProtoStoreImpl.java
@@ -21,7 +21,7 @@ import com.google.protobuf.ByteString;
 import com.google.protobuf.InvalidProtocolBufferException;
 import com.google.protobuf.MessageLite;
 import com.google.protobuf.Parser;
-import com.uber.simplestore.ScopeConfig;
+import com.uber.simplestore.NamespaceConfig;
 import com.uber.simplestore.SimpleStore;
 import com.uber.simplestore.SimpleStoreConfig;
 import com.uber.simplestore.proto.SimpleProtoStore;
@@ -30,9 +30,9 @@ import javax.annotation.Nullable;
 @SuppressWarnings("UnstableApiUsage")
 public final class SimpleProtoStoreImpl implements SimpleProtoStore {
   private final SimpleStore simpleStore;
-  private final ScopeConfig config;
+  private final NamespaceConfig config;
 
-  SimpleProtoStoreImpl(SimpleStore simpleStore, ScopeConfig config) {
+  SimpleProtoStoreImpl(SimpleStore simpleStore, NamespaceConfig config) {
     this.simpleStore = simpleStore;
     this.config = config;
   }
@@ -54,7 +54,7 @@ public final class SimpleProtoStoreImpl implements SimpleProtoStore {
             try {
               parsed = parser.parseFrom(bytes);
             } catch (InvalidProtocolBufferException e) {
-              if (config.equals(ScopeConfig.CACHE)) {
+              if (config.equals(NamespaceConfig.CACHE)) {
                 // A cache is allowed to be cleared whenever and we will try and give you a default
                 // instance instead.
                 return Futures.immediateFuture(parser.parseFrom(ByteString.EMPTY));

--- a/protosimplestore/src/test/java/com/uber/simplestore/proto/SimpleProtoStoreImplTest.java
+++ b/protosimplestore/src/test/java/com/uber/simplestore/proto/SimpleProtoStoreImplTest.java
@@ -22,7 +22,7 @@ import android.content.Context;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.protobuf.InvalidProtocolBufferException;
-import com.uber.simplestore.ScopeConfig;
+import com.uber.simplestore.NamespaceConfig;
 import com.uber.simplestore.SimpleStore;
 import com.uber.simplestore.proto.impl.SimpleProtoStoreFactory;
 import com.uber.simplestore.proto.test.TestProto;
@@ -112,7 +112,8 @@ public class SimpleProtoStoreImplTest {
       simpleStore.put(TEST_KEY, "garbage".getBytes(Charset.defaultCharset())).get();
     }
 
-    try (SimpleProtoStore store = SimpleProtoStoreFactory.create(context, "", ScopeConfig.CACHE)) {
+    try (SimpleProtoStore store =
+        SimpleProtoStoreFactory.create(context, "", NamespaceConfig.CACHE)) {
       TestProto.Basic failed = store.get(TEST_KEY, TestProto.Basic.parser()).get();
       assertThat(failed).isEqualTo(TestProto.Basic.getDefaultInstance());
     }

--- a/sample/src/main/java/com/uber/simplestore/sample/JavaActivity.java
+++ b/sample/src/main/java/com/uber/simplestore/sample/JavaActivity.java
@@ -28,7 +28,7 @@ import androidx.appcompat.app.AppCompatActivity;
 import com.google.common.util.concurrent.FutureCallback;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
-import com.uber.simplestore.ScopeConfig;
+import com.uber.simplestore.NamespaceConfig;
 import com.uber.simplestore.proto.Demo;
 import com.uber.simplestore.proto.SimpleProtoStore;
 import com.uber.simplestore.proto.impl.SimpleProtoStoreFactory;
@@ -37,19 +37,19 @@ import com.uber.simplestore.proto.impl.SimpleProtoStoreFactory;
 @SuppressWarnings("UnstableApiUsage")
 public class JavaActivity extends AppCompatActivity {
 
-  private static final String SCOPE_EXTRA = "scope";
+  private static final String NAMESPACE_EXTRA = "namespace";
   private TextView textView;
   private SimpleProtoStore simpleStore;
   private EditText editText;
   private View button;
-  int scope = 0;
+  int namespace = 0;
 
   @Override
   protected void onCreate(Bundle savedInstanceState) {
     super.onCreate(savedInstanceState);
     setContentView(R.layout.activity_java);
-    scope = getIntent().getIntExtra(SCOPE_EXTRA, 0);
-    setTitle("Sample Scope " + scope);
+    namespace = getIntent().getIntExtra(NAMESPACE_EXTRA, 0);
+    setTitle("Sample Namespace " + namespace);
     textView = findViewById(R.id.activity_main_text);
     editText = findViewById(R.id.activity_main_edit);
     button = findViewById(R.id.activity_main_save);
@@ -58,7 +58,7 @@ public class JavaActivity extends AppCompatActivity {
         .setOnClickListener(
             (v) -> {
               Intent intent = new Intent(this, JavaActivity.class);
-              intent.putExtra(SCOPE_EXTRA, scope + 1);
+              intent.putExtra(NAMESPACE_EXTRA, namespace + 1);
               startActivity(intent);
             });
     findViewById(R.id.activity_main_clear)
@@ -83,12 +83,12 @@ public class JavaActivity extends AppCompatActivity {
 
   private void initialize() {
     StringBuilder nesting = new StringBuilder();
-    for (int i = 0; i < scope; i++) {
+    for (int i = 0; i < namespace; i++) {
       nesting.append("/nest");
     }
     Log.w("Nesting: ", nesting.toString());
     simpleStore =
-        SimpleProtoStoreFactory.create(this, "main" + nesting.toString(), ScopeConfig.DEFAULT);
+        SimpleProtoStoreFactory.create(this, "main" + nesting.toString(), NamespaceConfig.DEFAULT);
     loadMessage();
   }
 

--- a/sample/src/main/java/com/uber/simplestore/sample/KotlinActivity.kt
+++ b/sample/src/main/java/com/uber/simplestore/sample/KotlinActivity.kt
@@ -10,7 +10,7 @@ import androidx.appcompat.app.AppCompatActivity
 import com.google.common.util.concurrent.FutureCallback
 import com.google.common.util.concurrent.Futures
 
-import com.uber.simplestore.ScopeConfig
+import com.uber.simplestore.NamespaceConfig
 import com.uber.simplestore.proto.Demo
 import com.uber.simplestore.proto.SimpleProtoStore
 import com.uber.simplestore.proto.impl.SimpleProtoStoreFactory
@@ -26,20 +26,20 @@ class KotlinActivity : AppCompatActivity() {
     private lateinit var simpleStore: SimpleProtoStore
     private lateinit var editText: EditText
     private lateinit var button: View
-    private var scope = 0
+    private var namespace = 0
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_kotlin)
-        scope = intent.getIntExtra(SCOPE_EXTRA, 0)
-        title = "Sample Scope $scope"
+        namespace = intent.getIntExtra(NAMESPACE_EXTRA, 0)
+        title = "Sample Namespace $namespace"
         textView = findViewById(R.id.activity_main_text)
         editText = findViewById(R.id.activity_main_edit)
         button = findViewById(R.id.activity_main_save)
         button.setOnClickListener { saveMessage() }
         findViewById<View>(R.id.activity_main_nest).setOnClickListener {
             val intent = Intent(this, KotlinActivity::class.java)
-            intent.putExtra(SCOPE_EXTRA, scope + 1)
+            intent.putExtra(NAMESPACE_EXTRA, namespace + 1)
             startActivity(intent)
         }
         findViewById<View>(R.id.activity_main_clear)
@@ -59,11 +59,11 @@ class KotlinActivity : AppCompatActivity() {
 
     private fun initialize() {
         val nesting = StringBuilder()
-        for (i in 0 until scope) {
+        for (i in 0 until namespace) {
             nesting.append("/nest")
         }
         Log.e("Test", nesting.toString())
-        simpleStore = SimpleProtoStoreFactory.create(this, "main$nesting", ScopeConfig.DEFAULT)
+        simpleStore = SimpleProtoStoreFactory.create(this, "main$nesting", NamespaceConfig.DEFAULT)
         loadMessage()
     }
 
@@ -109,6 +109,6 @@ class KotlinActivity : AppCompatActivity() {
     }
 
     companion object {
-        private const val SCOPE_EXTRA = "scope"
+        private const val NAMESPACE_EXTRA = "namespace"
     }
 }

--- a/simplestore/src/androidTest/java/com/uber/simplestore/SanityEspressoTest.java
+++ b/simplestore/src/androidTest/java/com/uber/simplestore/SanityEspressoTest.java
@@ -29,31 +29,31 @@ import org.junit.runner.RunWith;
 @LargeTest
 public class SanityEspressoTest {
 
-  private static final String TEST_SCOPE = "test_scope";
+  private static final String TEST_NAMESPACE = "test_namespace";
   private static final String KEY_ONE = "key_one";
   private static final String SAMPLE_STRING = "persisted_value";
   private static final byte[] SOME_BYTES = new byte[] {0xD, 0xE, 0xA, 0xD, 0x0, 0xB, 0xE, 0xE, 0xF};
   private Context context = InstrumentationRegistry.getInstrumentation().getTargetContext();
 
   @Test
-  public void defaultScope_bytes() throws Exception {
-    SimpleStore store = SimpleStoreFactory.create(context, TEST_SCOPE);
+  public void defaultNamespace_bytes() throws Exception {
+    SimpleStore store = SimpleStoreFactory.create(context, TEST_NAMESPACE);
     store.put(KEY_ONE, SOME_BYTES).get();
     store.close();
 
-    SimpleStore storeTwo = SimpleStoreFactory.create(context, TEST_SCOPE);
+    SimpleStore storeTwo = SimpleStoreFactory.create(context, TEST_NAMESPACE);
     byte[] fromDisk = storeTwo.get(KEY_ONE).get();
     assertEquals(SOME_BYTES, fromDisk);
     storeTwo.close();
   }
 
   @Test
-  public void defaultScope_string() throws Exception {
-    SimpleStore store = SimpleStoreFactory.create(context, TEST_SCOPE);
+  public void defaultNamespace_string() throws Exception {
+    SimpleStore store = SimpleStoreFactory.create(context, TEST_NAMESPACE);
     store.putString(KEY_ONE, SAMPLE_STRING).get();
     store.close();
 
-    SimpleStore storeTwo = SimpleStoreFactory.create(context, TEST_SCOPE);
+    SimpleStore storeTwo = SimpleStoreFactory.create(context, TEST_NAMESPACE);
     String fromDisk = storeTwo.getString(KEY_ONE).get();
     assertEquals(SAMPLE_STRING, fromDisk);
     storeTwo.close();
@@ -61,11 +61,12 @@ public class SanityEspressoTest {
 
   @Test
   public void cache() throws Exception {
-    SimpleStore store = SimpleStoreFactory.create(context, TEST_SCOPE, ScopeConfig.CACHE);
+    SimpleStore store = SimpleStoreFactory.create(context, TEST_NAMESPACE, NamespaceConfig.CACHE);
     store.putString(KEY_ONE, SAMPLE_STRING).get();
     store.close();
 
-    SimpleStore storeTwo = SimpleStoreFactory.create(context, TEST_SCOPE, ScopeConfig.CACHE);
+    SimpleStore storeTwo =
+        SimpleStoreFactory.create(context, TEST_NAMESPACE, NamespaceConfig.CACHE);
     String fromDisk = storeTwo.getString(KEY_ONE).get();
     assertEquals(SAMPLE_STRING, fromDisk);
     storeTwo.close();

--- a/simplestore/src/main/java/com/uber/simplestore/NamespaceConfig.java
+++ b/simplestore/src/main/java/com/uber/simplestore/NamespaceConfig.java
@@ -15,22 +15,22 @@
  */
 package com.uber.simplestore;
 
-/** Configure the store for a scope. */
-public final class ScopeConfig {
+/** Configure how the store accesses a namespace. */
+public final class NamespaceConfig {
   /**
-   * Marks a scope as performance & integrity critical.
+   * Opens a namespace as performance & integrity critical.
    *
    * <p>Bypasses future memory use optimizations.
    */
-  public static final ScopeConfig CRITICAL = new ScopeConfig();
+  public static final NamespaceConfig CRITICAL = new NamespaceConfig();
 
   /**
    * Use the cache directory.
    *
    * <p>Hides errors due to data corruption by returning a miss.
    */
-  public static final ScopeConfig CACHE = new ScopeConfig();
+  public static final NamespaceConfig CACHE = new NamespaceConfig();
 
   /** Default settings. */
-  public static final ScopeConfig DEFAULT = new ScopeConfig();
+  public static final NamespaceConfig DEFAULT = new NamespaceConfig();
 }

--- a/simplestore/src/main/java/com/uber/simplestore/SimpleStore.java
+++ b/simplestore/src/main/java/com/uber/simplestore/SimpleStore.java
@@ -75,7 +75,7 @@ public interface SimpleStore extends Closeable {
   @CheckReturnValue
   ListenableFuture<Boolean> contains(String key);
 
-  /** Delete all keys in this direct scope. */
+  /** Delete all keys in this direct namespace. */
   @CheckReturnValue
   ListenableFuture<Void> deleteAll();
 

--- a/simplestore/src/main/java/com/uber/simplestore/primitive/PrimitiveSimpleStoreFactory.java
+++ b/simplestore/src/main/java/com/uber/simplestore/primitive/PrimitiveSimpleStoreFactory.java
@@ -16,15 +16,16 @@
 package com.uber.simplestore.primitive;
 
 import android.content.Context;
-import com.uber.simplestore.ScopeConfig;
+import com.uber.simplestore.NamespaceConfig;
 import com.uber.simplestore.impl.SimpleStoreFactory;
 
 public final class PrimitiveSimpleStoreFactory {
-  public static PrimitiveSimpleStore create(Context context, String scope) {
-    return create(context, scope, ScopeConfig.DEFAULT);
+  public static PrimitiveSimpleStore create(Context context, String namespace) {
+    return create(context, namespace, NamespaceConfig.DEFAULT);
   }
 
-  public static PrimitiveSimpleStore create(Context context, String scope, ScopeConfig config) {
-    return new PrimitiveSimpleStoreImpl(SimpleStoreFactory.create(context, scope, config));
+  public static PrimitiveSimpleStore create(
+      Context context, String namespace, NamespaceConfig config) {
+    return new PrimitiveSimpleStoreImpl(SimpleStoreFactory.create(context, namespace, config));
   }
 }

--- a/simplestore/src/test/java/com/uber/simplestore/impl/SimpleStoreImplTest.java
+++ b/simplestore/src/test/java/com/uber/simplestore/impl/SimpleStoreImplTest.java
@@ -23,7 +23,7 @@ import android.content.Context;
 import com.google.common.util.concurrent.FutureCallback;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
-import com.uber.simplestore.ScopeConfig;
+import com.uber.simplestore.NamespaceConfig;
 import com.uber.simplestore.SimpleStore;
 import com.uber.simplestore.SimpleStoreConfig;
 import com.uber.simplestore.StoreClosedException;
@@ -161,30 +161,30 @@ public final class SimpleStoreImplTest {
   }
 
   @Test
-  public void scopes() throws Exception {
-    String someScope = "bar";
+  public void namespaces() throws Exception {
+    String someNamespace = "bar";
     String value = "some value";
-    try (SimpleStore scopedBase =
-        SimpleStoreFactory.create(context, someScope, ScopeConfig.DEFAULT)) {
-      ListenableFuture<String> success = scopedBase.putString("foo", value);
+    try (SimpleStore namespacedBase =
+        SimpleStoreFactory.create(context, someNamespace, NamespaceConfig.DEFAULT)) {
+      ListenableFuture<String> success = namespacedBase.putString("foo", value);
       success.get();
     }
 
-    try (SimpleStore scopedFactory =
-        SimpleStoreFactory.create(context, someScope, ScopeConfig.DEFAULT)) {
-      ListenableFuture<String> read = scopedFactory.getString("foo");
+    try (SimpleStore namespacedFactory =
+        SimpleStoreFactory.create(context, someNamespace, NamespaceConfig.DEFAULT)) {
+      ListenableFuture<String> read = namespacedFactory.getString("foo");
       assertThat(read.get()).isEqualTo(value);
     }
   }
 
   @Test
-  public void oneInstancePerScope() {
-    String someScope = "foo";
+  public void oneInstancePerNamespace() {
+    String someNamespace = "foo";
     try (SimpleStore ignoredOuter = SimpleStoreFactory.create(context, "")) {
       try (SimpleStore ignored =
-          SimpleStoreFactory.create(context, someScope, ScopeConfig.DEFAULT)) {
+          SimpleStoreFactory.create(context, someNamespace, NamespaceConfig.DEFAULT)) {
         try {
-          SimpleStoreFactory.create(context, someScope, ScopeConfig.DEFAULT);
+          SimpleStoreFactory.create(context, someNamespace, NamespaceConfig.DEFAULT);
           fail();
         } catch (IllegalStateException e) {
           // expected.

--- a/simplestore/src/test/java/com/uber/simplestore/primitive/PrimitiveSimpleStoreTest.java
+++ b/simplestore/src/test/java/com/uber/simplestore/primitive/PrimitiveSimpleStoreTest.java
@@ -19,7 +19,7 @@ import static com.google.common.truth.Truth.assertThat;
 
 import android.content.Context;
 import com.google.common.util.concurrent.ListenableFuture;
-import com.uber.simplestore.ScopeConfig;
+import com.uber.simplestore.NamespaceConfig;
 import com.uber.simplestore.SimpleStoreConfig;
 import com.uber.simplestore.impl.SimpleStoreFactory;
 import org.junit.After;
@@ -44,7 +44,7 @@ public final class PrimitiveSimpleStoreTest {
   @Test
   public void whenMissingOnDisk_numbers() throws Exception {
     try (PrimitiveSimpleStore store =
-        PrimitiveSimpleStoreFactory.create(context, "", ScopeConfig.DEFAULT)) {
+        PrimitiveSimpleStoreFactory.create(context, "", NamespaceConfig.DEFAULT)) {
       assertThat(store.contains(TEST_KEY).get()).isFalse();
 
       Integer integer = store.getInt(TEST_KEY).get();
@@ -62,7 +62,7 @@ public final class PrimitiveSimpleStoreTest {
   @Test
   public void whenMissingOnDisk_string() throws Exception {
     try (PrimitiveSimpleStore store =
-        PrimitiveSimpleStoreFactory.create(context, "", ScopeConfig.DEFAULT)) {
+        PrimitiveSimpleStoreFactory.create(context, "", NamespaceConfig.DEFAULT)) {
       assertThat(store.contains(TEST_KEY).get()).isFalse();
 
       String s = store.getString(TEST_KEY).get();
@@ -76,7 +76,7 @@ public final class PrimitiveSimpleStoreTest {
   @Test
   public void whenMissingOnDisk_boolean() throws Exception {
     try (PrimitiveSimpleStore store =
-        PrimitiveSimpleStoreFactory.create(context, "", ScopeConfig.DEFAULT)) {
+        PrimitiveSimpleStoreFactory.create(context, "", NamespaceConfig.DEFAULT)) {
       assertThat(store.contains(TEST_KEY).get()).isFalse();
 
       boolean b = store.getBoolean(TEST_KEY).get();


### PR DESCRIPTION
Scope is an overloaded term, especially when using with Motif/RIBs.
Namespace is more appropriate for how the data is represented on disk.
