### PR TITLE
Downgrade proto lite

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -67,8 +67,9 @@ def kotlin = [
 def external = [
         guavaAndroid: 'com.google.guava:guava:27.0.1-android',
         findBugs    : 'com.google.code.findbugs:jsr305:3.0.2',
-        protoLite   : 'com.google.protobuf:protobuf-javalite:3.9.0',
-        protoc      : '3.9.0',
+        protoLite   : 'com.google.protobuf:protobuf-lite:3.0.1',
+        protoc      : '3.4.0',
+        protocLite  : '3.0.0',
 ]
 
 ext.deps = [

--- a/protosimplestore/build.gradle
+++ b/protosimplestore/build.gradle
@@ -39,12 +39,18 @@ protobuf {
     protoc {
         artifact = "com.google.protobuf:protoc:${deps.external.protoc}"
     }
+    plugins {
+        javalite {
+            artifact = "com.google.protobuf:protoc-gen-javalite:${deps.external.protocLite}"
+        }
+    }
     generateProtoTasks {
         all().each { task ->
             task.builtins {
-                java {
-                    option 'lite'
-                }
+                remove java
+            }
+            task.plugins {
+                javalite { }
             }
         }
     }

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -26,12 +26,18 @@ protobuf {
     protoc {
         artifact = "com.google.protobuf:protoc:${deps.external.protoc}"
     }
+    plugins {
+        javalite {
+            artifact = "com.google.protobuf:protoc-gen-javalite:${deps.external.protocLite}"
+        }
+    }
     generateProtoTasks {
         all().each { task ->
             task.builtins {
-                java {
-                    option 'lite'
-                }
+                remove java
+            }
+            task.plugins {
+                javalite { }
             }
         }
     }


### PR DESCRIPTION
Newer protolite is currently broken on API 19 - 23. Downgrade until
https://github.com/protocolbuffers/protobuf/issues/6305 is resolved
