### PR TITLE
adds the SimpleStoreFactory.getOrCreate method

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -34,7 +34,7 @@ def build = [
         errorProneTestHelpers: "com.google.errorprone:error_prone_test_helpers:${versions.errorProne}",
         nullAway             : 'com.uber.nullaway:nullaway:0.8.0',
         gradlePlugins        : [
-                android   : '7.0.0-alpha01',
+                android   : '4.2.0',
                 kotlin    : '1.3.72',
                 errorProne: '0.8',
                 nullAway  : '0.2',

--- a/simplestore/src/test/java/com/uber/simplestore/impl/SimpleStoreFactoryTest.java
+++ b/simplestore/src/test/java/com/uber/simplestore/impl/SimpleStoreFactoryTest.java
@@ -16,10 +16,15 @@
 package com.uber.simplestore.impl;
 
 import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.*;
 
 import android.content.Context;
 import com.uber.simplestore.DirectoryProvider;
 import com.uber.simplestore.SimpleStore;
+import java.util.Objects;
+import javax.annotation.Nullable;
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
@@ -31,21 +36,56 @@ public final class SimpleStoreFactoryTest {
   private final Context context = RuntimeEnvironment.systemContext;
   private final DirectoryProvider directoryProvider = new AndroidDirectoryProvider(context);
 
+  @Nullable private SimpleStore root = null;
+
+  @Nullable private SimpleStore parent = null;
+
+  @Nullable private SimpleStore child = null;
+
+  @Nullable private SimpleStore leaf = null;
+
+  @Before
+  public void setUp() {
+    root = SimpleStoreFactory.create(directoryProvider, "");
+    parent = SimpleStoreFactory.create(directoryProvider, "parent");
+    child = SimpleStoreFactory.create(directoryProvider, "parent/child");
+    leaf = SimpleStoreFactory.create(directoryProvider, "leaf");
+  }
+
   @Test
   public void findChildren() {
-    SimpleStore root = SimpleStoreFactory.create(directoryProvider, "");
-    SimpleStore parent = SimpleStoreFactory.create(directoryProvider, "parent");
-    SimpleStore child = SimpleStoreFactory.create(directoryProvider, "parent/child");
-    SimpleStore leaf = SimpleStoreFactory.create(directoryProvider, "leaf");
-
     assertThat(SimpleStoreFactory.getOpenChildren("leaf")).isEmpty();
     assertThat(SimpleStoreFactory.getOpenChildren("parent/child")).isEmpty();
     assertThat(SimpleStoreFactory.getOpenChildren("parent")).containsExactly(child);
     assertThat(SimpleStoreFactory.getOpenChildren("")).containsExactly(parent, child, leaf);
+  }
 
-    root.close();
-    parent.close();
-    child.close();
-    leaf.close();
+  @Test(expected = IllegalStateException.class)
+  public void createShouldThrowAExceptionWhenInstanceAlreadyExist() {
+    SimpleStoreFactory.create(directoryProvider, "");
+  }
+
+  @Test
+  public void getOrCreateShouldReturnAnInstanceWhenInstanceAlreadyExist() {
+    SimpleStore store = SimpleStoreFactory.getOrCreate(directoryProvider, "");
+    assertEquals(root, store);
+  }
+
+  @Test
+  public void getOrCreateShouldReturnAnNewInstanceForClosedNamespaces() {
+    SimpleStore store = SimpleStoreFactory.getOrCreate(directoryProvider, "test");
+    assertNotNull(store);
+    store.close();
+    store = SimpleStoreFactory.getOrCreate(directoryProvider, "test");
+    assertNotNull(store);
+    store.close();
+  }
+
+  @After
+  public void tearDown() {
+    Objects.requireNonNull(root).close();
+    Objects.requireNonNull(parent).close();
+    Objects.requireNonNull(child).close();
+    Objects.requireNonNull(leaf).close();
   }
 }


### PR DESCRIPTION
Adds the method getOrCreate to SimpleStoreFactory.
This new method will create a new store instance if not exists an opened store for the namespace, or return an already opened store if already exist opened store for the namespace.

This new method will maintain the current behavior that permits only one store instance by namespace, at the same time that will provide a more resilient method for developers mistakes.