### PR TITLE
Fix flaky test "deleteAll_twice"

### DIFF
--- a/simplestore/src/test/java/com/uber/simplestore/impl/SimpleStoreImplTest.java
+++ b/simplestore/src/test/java/com/uber/simplestore/impl/SimpleStoreImplTest.java
@@ -149,12 +149,22 @@ public final class SimpleStoreImplTest {
   }
 
   @Test
-  public void deleteAll_twice() throws Exception {
+  public void deleteAll_twice_sequential_success() throws Exception {
     try (SimpleStore store = SimpleStoreFactory.create(directoryProvider, "twice")) {
       ListenableFuture<Void> first = store.deleteAllNow();
-      ListenableFuture<Void> second = store.deleteAllNow();
       first.get();
+      ListenableFuture<Void> second = store.deleteAllNow();
       second.get();
+    }
+  }
+
+  @Test(expected = IllegalStateException.class)
+  public void deleteAll_twice_interwoven_failure() {
+    try (SimpleStore store = SimpleStoreFactory.create(directoryProvider, "twice")) {
+      // prevent first call from finishing
+      enqueueBlockingOperation(store);
+      store.deleteAllNow();
+      store.deleteAllNow();
     }
   }
 


### PR DESCRIPTION
This pull request spawns from the error I ran into while trying to merge https://github.com/uber/simple-store/pull/91#issuecomment-1530706478 - and it seems to be due to a possible race condition that the test occasionally fails.

The flakiness comes from `failQueueThenRun` (called by `deleteAllNow`) sets `flush` on the current thread (and throws exception if already set) while resets `flush` on an [ordered io](https://github.com/uber/simple-store/blob/main/simplestore/src/main/java/com/uber/simplestore/impl/SimpleStoreImpl.java#L56) thread. 

This pull request updates the `flush` variable to `AtomicReference` to be more explicit about its multi-threaded nature and split the `deleteAll_twice` to assert for the sequential case and the interwoven case.