### PR TITLE
downgrade dokka to 1.6.10

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -43,7 +43,7 @@ def build = [
                 protobuf  : '0.8.12',
                 spotless  : '4.3.0',
                 mavenPublish : '0.22.0',
-                dokka     : '1.9.10',
+                dokka     : '1.6.10',
         ]
 ]
 


### PR DESCRIPTION
compatibility issue with AGP preventing javadoc generation
https://github.com/Kotlin/dokka/issues/2452 

tested document publishing and it still works