### PR TITLE
Remove unused app_name string resource

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,7 @@ on:
 jobs:
   build:
     name: JDK ${{ matrix.java_version }}
-    runs-on: macOS-latest
+    runs-on: macos-13
     strategy:
       matrix:
         java_version: [11]
@@ -53,7 +53,7 @@ jobs:
           abi: x86
       - name: Full check
         run: ./gradlew check --stacktrace
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         with:
           name: Sample App
           path: sample/build/outputs

--- a/protosimplestore/src/main/res/values/strings.xml
+++ b/protosimplestore/src/main/res/values/strings.xml
@@ -1,3 +1,0 @@
-<resources>
-    <string name="app_name">Proto SimpleStore</string>
-</resources>


### PR DESCRIPTION
This seemingly trivial removal of an unused `app_name` can help make resource resolution a bit easier downstream since `app_name` is often the resource name that APKs are using to identify the name of the application - it seems unlikely anyone is using simple-store for this string.